### PR TITLE
Fix camt.053.001.02 amount being always "None" and add support for DateTime of opening/closing balance

### DIFF
--- a/pycamt/parser.py
+++ b/pycamt/parser.py
@@ -288,6 +288,11 @@ class Camt053Parser:
                 if tx_detail.find(".//RltdPties//Dbtr//Nm", self.namespaces) is not None
                 else None
             ),
+            "PurposeCode": (
+                tx_detail.find(".//Purp//Cd", self.namespaces).text
+                if tx_detail.find(".//Purp//Cd", self.namespaces) is not None
+                else None
+            ),
             "RemittanceInformation": (
                 tx_detail.find(".//RmtInf//Ustrd", self.namespaces).text
                 if tx_detail.find(".//RmtInf//Ustrd", self.namespaces) is not None

--- a/pycamt/parser.py
+++ b/pycamt/parser.py
@@ -262,7 +262,7 @@ class Camt053Parser:
             Detailed information extracted from the transaction detail element.
         """
 
-        return {
+        data = {
             "EndToEndId": (
                 tx_detail.find(".//Refs//EndToEndId", self.namespaces).text
                 if tx_detail.find(".//Refs//EndToEndId", self.namespaces) is not None
@@ -294,6 +294,8 @@ class Camt053Parser:
                 else None
             ),
         }
+
+        return {key: value for key, value in data.items() if value is not None}
 
     def get_statement_info(self):
         """

--- a/pycamt/parser.py
+++ b/pycamt/parser.py
@@ -295,6 +295,16 @@ class Camt053Parser:
             ),
         }
 
+        structured_remittance_elem = tx_detail.find(".//RmtInf//Strd", self.namespaces)
+
+        if structured_remittance_elem is not None:
+            ref_elem = structured_remittance_elem.find(".//CdtrRefInf//Ref", self.namespaces)
+            additional_ref_elem = structured_remittance_elem.find(".//AddtlRmtInf", self.namespaces)
+
+            data["RemittanceInformation"] = ref_elem.text if ref_elem is not None else None
+            data["AdditionalRemittanceInformation"] = additional_ref_elem.text if additional_ref_elem is not None else None
+
+
         return {key: value for key, value in data.items() if value is not None}
 
     def get_statement_info(self):

--- a/pycamt/parser.py
+++ b/pycamt/parser.py
@@ -283,9 +283,19 @@ class Camt053Parser:
                 if tx_detail.find(".//RltdPties//Cdtr//Nm", self.namespaces) is not None
                 else None
             ),
+            "CreditorIBAN": (
+                tx_detail.find(".//RltdPties//CdtrAcct//Id//IBAN", self.namespaces).text
+                if tx_detail.find(".//RltdPties//CdtrAcct//Id//IBAN", self.namespaces) is not None
+                else None
+            ),
             "DebtorName": (
                 tx_detail.find(".//RltdPties//Dbtr//Nm", self.namespaces).text
                 if tx_detail.find(".//RltdPties//Dbtr//Nm", self.namespaces) is not None
+                else None
+            ),
+            "DebtorIBAN": (
+                tx_detail.find(".//RltdPties//DbtrAcct//Id//IBAN", self.namespaces).text
+                if tx_detail.find(".//RltdPties//DbtrAcct//Id//IBAN", self.namespaces) is not None
                 else None
             ),
             "PurposeCode": (

--- a/pycamt/parser.py
+++ b/pycamt/parser.py
@@ -360,7 +360,11 @@ class Camt053Parser:
                 # Extract date
                 date_elem = balance_elem.find(".//Dt//Dt", self.namespaces)
                 date_text = date_elem.text if date_elem is not None else None
-                
+
+                date_time_elem = balance_elem.find(".//Dt//DtTm", self.namespaces)
+                if date_time_elem is not None:
+                    date_text = date_time_elem.text
+
                 # Store based on balance type
                 if balance_type == "OPBD":
                     result["OpeningBalance"] = amount_text

--- a/pycamt/parser.py
+++ b/pycamt/parser.py
@@ -210,6 +210,7 @@ class Camt053Parser:
             A dictionary containing common data extracted from the entry.
         """
         return {
+            "TransactionID": entry.find(".//AcctSvcrRef", self.namespaces).text,
             "Amount": entry.find(".//Amt", self.namespaces).text,
             "Currency": entry.find(".//Amt", self.namespaces).attrib.get("Ccy"),
             "CreditDebitIndicator": entry.find(".//CdtDbtInd", self.namespaces).text,


### PR DESCRIPTION
Tested with camt.053.001.02 files from Revolut Business.

### Amount always `None`
When merging two Python dictionaries using the ** unpacking operator, if the same key exists in both dictionaries, the value from the dictionary that's unpacked last will overwrite the value from the first.

Since Amount is being parsed in both `_extract_common_entry_data` and `_extract_transaction_details` if the latter returned None, the common value would be overwritten. 

### Add support for Datetime OpeningBalanceDate/ClosingBalanceDate

In recent PR support for this parsing was added, but it only expected the `//Dt//Dt` to be present. Revolut for example provides only `.//Dt//DtTm` in XML so the opening/closing balance date was always `None`. 

### Add support for structured remittance data

Some countries have sturctured remittance data. Added support for parsing remittance and additional remittance data that is present in the structured format. 

## Fixes

- Added CreditorIBAN and DebtorIBAN to close https://github.com/ODAncona/pycamt/issues/5
- Add TransactionID (AcctSvcrRef) - unique reference from the bank to identify the transaction. Usefull for storing data in database to identify duplicate imports

PS: Can you also update the pypi version with the latest changes?