### PR TITLE
CAMT53 v8 and v12 support, Multiple Statement Support

### DIFF
--- a/pycamt/parser.py
+++ b/pycamt/parser.py
@@ -356,12 +356,13 @@ class Camt053Parser:
             - ClosingBalanceDate: Date of the closing balance
             - Currency: Account currency (if available)
         """
-        stmt = self.tree.find(".//Stmt", self.namespaces)
-        if stmt is None:
+        statements = []
+        stmts = self.tree.findall(".//Stmt", self.namespaces)
+        if len(stmts) == 0:
             # Maybe we have a Rpt file
-            stmt = self.tree.find(".//Rpt", self.namespaces)
+            stmts = self.tree.findall(".//Rpt", self.namespaces)
 
-        if stmt is not None:
+        for stmt in stmts:
             # Extract IBAN
             iban = stmt.find(".//Acct//Id//IBAN", self.namespaces)
             iban_text = iban.text if iban is not None else None
@@ -419,6 +420,6 @@ class Camt053Parser:
                     result["ClosingBalance"] = amount_text
                     result["ClosingBalanceDate"] = date_text
             
-            return result
+            statements.append(result)
         
-        return {}
+        return statements

--- a/pycamt/parser.py
+++ b/pycamt/parser.py
@@ -1,7 +1,4 @@
-from io import StringIO
-
-from defusedxml import ElementTree as ET
-
+from lxml import etree as ET
 
 class Camt053Parser:
     """
@@ -31,7 +28,7 @@ class Camt053Parser:
         Extracts statement information like IBAN and balances from the CAMT.053 file.
     """
 
-    def __init__(self, xml_data):
+    def __init__(self, xml_data: str | bytes):
         """
         Initializes the Camt053Parser with XML data.
 
@@ -41,7 +38,7 @@ class Camt053Parser:
             XML data as a string representation of CAMT.053 content.
         """
         self.tree = ET.fromstring(xml_data)
-        self.namespaces = self._detect_namespaces(xml_data)
+        self.namespaces = self.tree.nsmap
         self.version = self._detect_version()
 
     @classmethod
@@ -59,28 +56,9 @@ class Camt053Parser:
         Camt053Parser
             An instance of the parser initialized with the XML content from the file.
         """
-        with open(file_path, encoding="utf-8") as file:
+        with open(file_path, 'rb') as file:
             xml_data = file.read()
         return cls(xml_data)
-
-    def _detect_namespaces(self, xml_data):
-        """
-        Detects and extracts namespaces from the XML data for XPath queries.
-
-        Parameters
-        ----------
-        xml_data : str
-            XML data from which namespaces are to be extracted.
-
-        Returns
-        -------
-        dict
-            A dictionary of namespace prefixes to namespace URIs.
-        """
-        namespaces = {}
-        for _, elem in ET.iterparse(StringIO(xml_data), events=("start-ns",)):
-            namespaces[elem[0]] = elem[1]
-        return namespaces
 
     def _detect_version(self):
         """

--- a/pycamt/parser.py
+++ b/pycamt/parser.py
@@ -96,6 +96,8 @@ class Camt053Parser:
             "camt.053.001.02",
             "camt.053.001.03",
             "camt.053.001.04",
+            "camt.053.001.08",
+            "camt.053.001.12",
         ]:
             if version in root.tag:
                 return version
@@ -195,6 +197,18 @@ class Camt053Parser:
                         )
         return transactions
 
+    def _parse_status(self, entry):
+        status = None
+        if entry is not None:
+            child_element = entry.find(".//Cd", self.namespaces)
+
+            if child_element is not None:
+                status = child_element.text
+            else:
+                status = entry.text
+
+        return status
+
     def _extract_common_entry_data(self, entry):
         """
         Extracts common data applicable to all transactions within an entry.
@@ -219,13 +233,9 @@ class Camt053Parser:
                 if entry.find(".//RvslInd", self.namespaces) is not None
                 else None
             ),
-            "Status": (
-                entry.find(".//Sts", self.namespaces).text
-                if entry.find(".//Sts", self.namespaces) is not None
-                else None
-            ),
-            "BookingDate": entry.find(".//BookgDt//Dt", self.namespaces).text,
-            "ValueDate": entry.find(".//ValDt//Dt", self.namespaces).text,
+            "Status": self._parse_status(entry=entry.find(".//Sts", self.namespaces)),
+            "BookingDate": entry.find(".//BookgDt//*", self.namespaces).text,
+            "ValueDate": entry.find(".//ValDt//*", self.namespaces).text,
             "BankTransactionCode": (
                 entry.find(".//BkTxCd//Domn//Cd", self.namespaces).text
                 if entry.find(".//BkTxCd//Domn//Cd", self.namespaces) is not None
@@ -319,7 +329,6 @@ class Camt053Parser:
 
             data["RemittanceInformation"] = ref_elem.text if ref_elem is not None else None
             data["AdditionalRemittanceInformation"] = additional_ref_elem.text if additional_ref_elem is not None else None
-
 
         return {key: value for key, value in data.items() if value is not None}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0"
-defusedxml = "^0.7.1"
+lxml = ">=4.4.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -19,6 +19,14 @@ def parser():
                     </Id>
                 </Acct>
                 <Bal>
+                    <Tp>
+                        <CdOrPrtry>
+                            <Cd>OPBD</Cd>
+                        </CdOrPrtry>
+                    </Tp>
+                    <Dt>
+                        <Dt>2025-07-31</Dt>
+                    </Dt>
                     <Amt Ccy="EUR">1000.00</Amt>
                 </Bal>
                 <Ntry>
@@ -30,6 +38,7 @@ def parser():
                     <ValDt>
                         <Dt>2020-06-23</Dt>
                     </ValDt>
+                    <AcctSvcrRef>123</AcctSvcrRef>
                     <NtryDtls>
                         <TxDtls>
                             <Refs>
@@ -70,8 +79,12 @@ class TestCamt053Parser:
         assert transaction["ValueDate"] == "2020-06-23"
 
     def test_get_statement_info(self, parser):
-        expected = {
+        expected = [{
             "IBAN": "GB33BUKB20201555555555",
             "OpeningBalance": "1000.00",
-        }
+            "Currency": None,
+            "ClosingBalance": None,
+            "OpeningBalanceDate": "2025-07-31",
+            "ClosingBalanceDate": None
+        }]
         assert parser.get_statement_info() == expected


### PR DESCRIPTION
- Added support for CAMT53 V8 and V12 parsing
-  Added support for MultipleStatements https://github.com/ODAncona/pycamt/issues/2
   - Changed response of get_statement_info to a *list* to be able to return multiple statements
   - updated test to reflect new get_statement_info
   - added AccountIBAN to each transaction to be able to link it to a specific statement (sometimes CreditorIBAN or DebtorIBAN are not set - card payments etc.)

- Swap defusedxml for lxml (defusedxml hasn't been updated since March 2021)